### PR TITLE
Fix wrong declaration of linux_directory in docs

### DIFF
--- a/docs/resources/directory.md
+++ b/docs/resources/directory.md
@@ -5,8 +5,8 @@ Manage linux directory with support for Terraform update lifecycle.
 ## Example Usage
 
 ```hcl
-resource "linux_file" "file" {
-    path = "/tmp/linux/file"
+resource "linux_directory" "file" {
+    path = "/tmp/linux/directory"
     owner = 1000
     group = 1000
     mode = "755"


### PR DESCRIPTION
This PR changes the example of how to use the `linux_directory` ressource.
Change ressource type from `linux_file` to `linux_directory`